### PR TITLE
Fix Initial Exchange Rate in Networks

### DIFF
--- a/config/networks.js
+++ b/config/networks.js
@@ -49,7 +49,7 @@ function tokenProperties({address, contract, definition, deployment, properties}
   let cTokenProps = {};
   if (definition === 'CToken') {
     cTokenProps = {      
-      initial_exchange_rate_mantissa: properties.initial_exchange_rate.toString(),
+      initial_exchange_rate_mantissa: toNumberString(properties.initial_exchange_rate),
       admin: findAccount(state, accounts, properties.admin),
       underlying: properties.underlying ? state[properties.underlying.ref].address : "" // Note: this key is required, even if it's blank
     } 

--- a/networks/kovan-abi.json
+++ b/networks/kovan-abi.json
@@ -7857,13 +7857,13 @@
         {
           "indexed": false,
           "internalType": "uint256",
-          "name": "oldCompRateMantissa",
+          "name": "oldCompRate",
           "type": "uint256"
         },
         {
           "indexed": false,
           "internalType": "uint256",
-          "name": "newCompRateMantissa",
+          "name": "newCompRate",
           "type": "uint256"
         }
       ],
@@ -26272,13 +26272,13 @@
         {
           "indexed": false,
           "internalType": "uint256",
-          "name": "oldCompRateMantissa",
+          "name": "oldCompRate",
           "type": "uint256"
         },
         {
           "indexed": false,
           "internalType": "uint256",
-          "name": "newCompRateMantissa",
+          "name": "newCompRate",
           "type": "uint256"
         }
       ],

--- a/networks/kovan.json
+++ b/networks/kovan.json
@@ -217,7 +217,7 @@
       "symbol": "cZRX",
       "decimals": 8,
       "address": "0xAf45ae737514C8427D373D50Cd979a242eC59e5a",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "0x162c44e53097e7B5aaE939b297ffFD6Bf90D1EE3",
       "contract": "CErc20Immutable"
@@ -227,7 +227,7 @@
       "symbol": "cWBTC",
       "decimals": 8,
       "address": "0xa1fAA15655B0e7b6B6470ED3d096390e6aD93Abb",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "20000000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "0xd3A691C852CDB01E281545A27064741F0B7f6825",
       "contract": "CErc20Immutable"
@@ -237,7 +237,7 @@
       "symbol": "cUSDT",
       "decimals": 8,
       "address": "0x3f0A0EA2f86baE6362CF9799B523BA06647Da018",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "20000000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "0x07de306FF27a2B630B1141956844eB1552B956B5",
       "contract": "CErc20Delegator"
@@ -247,7 +247,7 @@
       "symbol": "cUSDC",
       "decimals": 8,
       "address": "0x4a92E71227D294F041BD82dd8f78591B75140d63",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "0xb7a4F3E9097C08dA09517b5aB877F7a917224ede",
       "contract": "CErc20Immutable"
@@ -257,7 +257,7 @@
       "symbol": "cETH",
       "decimals": 8,
       "address": "0x41B5844f4680a8C38fBb695b7F9CFd1F64474a72",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "",
       "contract": "CEther"
@@ -267,7 +267,7 @@
       "symbol": "cSAI",
       "decimals": 8,
       "address": "0xb3f7fB482492f4220833De6D6bfCC81157214bEC",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "0xD1308F63823221518Ec88EB209CBaa1ac182105f",
       "contract": "CErc20Immutable"
@@ -277,7 +277,7 @@
       "symbol": "cREP",
       "decimals": 8,
       "address": "0xA4eC170599a1Cf87240a35b9B1B8Ff823f448b57",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "0x50DD65531676F718B018De3dc48F92B53D756996",
       "contract": "CErc20Immutable"
@@ -287,7 +287,7 @@
       "symbol": "cBAT",
       "decimals": 8,
       "address": "0x4a77fAeE9650b09849Ff459eA1476eaB01606C7a",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "0x482dC9bB08111CB875109B075A40881E48aE02Cd",
       "contract": "CErc20Immutable"
@@ -297,7 +297,7 @@
       "symbol": "cDAI",
       "decimals": 8,
       "address": "0xF0d0EB522cfa50B716B3b1604C4F0fA6f04376AD",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa",
       "contract": "CErc20Delegator"
@@ -316,7 +316,7 @@
       "symbol": "cZRX",
       "decimals": 8,
       "address": "0xAf45ae737514C8427D373D50Cd979a242eC59e5a",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "0x162c44e53097e7B5aaE939b297ffFD6Bf90D1EE3",
       "contract": "CErc20Immutable"
@@ -326,7 +326,7 @@
       "symbol": "cWBTC",
       "decimals": 8,
       "address": "0xa1fAA15655B0e7b6B6470ED3d096390e6aD93Abb",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "20000000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "0xd3A691C852CDB01E281545A27064741F0B7f6825",
       "contract": "CErc20Immutable"
@@ -336,7 +336,7 @@
       "symbol": "cUSDT",
       "decimals": 8,
       "address": "0x3f0A0EA2f86baE6362CF9799B523BA06647Da018",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "20000000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "0x07de306FF27a2B630B1141956844eB1552B956B5",
       "contract": "CErc20Delegator"
@@ -346,7 +346,7 @@
       "symbol": "cUSDC",
       "decimals": 8,
       "address": "0x4a92E71227D294F041BD82dd8f78591B75140d63",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "0xb7a4F3E9097C08dA09517b5aB877F7a917224ede",
       "contract": "CErc20Immutable"
@@ -356,7 +356,7 @@
       "symbol": "cETH",
       "decimals": 8,
       "address": "0x41B5844f4680a8C38fBb695b7F9CFd1F64474a72",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "",
       "contract": "CEther"
@@ -366,7 +366,7 @@
       "symbol": "cSAI",
       "decimals": 8,
       "address": "0xb3f7fB482492f4220833De6D6bfCC81157214bEC",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "0xD1308F63823221518Ec88EB209CBaa1ac182105f",
       "contract": "CErc20Immutable"
@@ -376,7 +376,7 @@
       "symbol": "cREP",
       "decimals": 8,
       "address": "0xA4eC170599a1Cf87240a35b9B1B8Ff823f448b57",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "0x50DD65531676F718B018De3dc48F92B53D756996",
       "contract": "CErc20Immutable"
@@ -386,7 +386,7 @@
       "symbol": "cBAT",
       "decimals": 8,
       "address": "0x4a77fAeE9650b09849Ff459eA1476eaB01606C7a",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "0x482dC9bB08111CB875109B075A40881E48aE02Cd",
       "contract": "CErc20Immutable"
@@ -396,7 +396,7 @@
       "symbol": "cDAI",
       "decimals": 8,
       "address": "0xF0d0EB522cfa50B716B3b1604C4F0fA6f04376AD",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0xA776184Fd6F545DAe5f51361dBcC9018549a9749",
       "underlying": "0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa",
       "contract": "CErc20Delegator"

--- a/networks/ropsten.json
+++ b/networks/ropsten.json
@@ -217,7 +217,7 @@
       "symbol": "cZRX",
       "decimals": 8,
       "address": "0x00e02a5200CE3D5b5743F5369Deb897946C88121",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "0xE4C6182EA459E63B8F1be7c428381994CcC2D49c",
       "contract": "CErc20Immutable"
@@ -227,7 +227,7 @@
       "symbol": "cWBTC",
       "decimals": 8,
       "address": "0x58145Bc5407D63dAF226e4870beeb744C588f149",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "20000000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "0xBde8bB00A7eF67007A96945B3a3621177B615C44",
       "contract": "CErc20Immutable"
@@ -237,7 +237,7 @@
       "symbol": "cUSDT",
       "decimals": 8,
       "address": "0x135669c2dcBd63F639582b313883F101a4497F76",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "0x516de3a7A567d81737e3a46ec4FF9cFD1fcb0136",
       "contract": "CErc20Delegator"
@@ -247,7 +247,7 @@
       "symbol": "cUSDC",
       "decimals": 8,
       "address": "0x8aF93cae804cC220D1A608d4FA54D1b6ca5EB361",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "0x0D9C8723B343A8368BebE0B5E89273fF8D712e3C",
       "contract": "CErc20Immutable"
@@ -257,7 +257,7 @@
       "symbol": "cETH",
       "decimals": 8,
       "address": "0xBe839b6D93E3eA47eFFcCA1F27841C917a8794f3",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "",
       "contract": "CEther"
@@ -267,7 +267,7 @@
       "symbol": "cSAI",
       "decimals": 8,
       "address": "0xc4d2A5872E16BC9E6557bE8B24683D96EB6ADca9",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "0x26fF7457496600C63b3E8902C9f871E60eDec4e4",
       "contract": "CErc20Immutable"
@@ -277,7 +277,7 @@
       "symbol": "cREP",
       "decimals": 8,
       "address": "0x8F2c8B147A3D316d2b98f32F3864746F034A55a2",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "0x6FD34013CDD2905d8d27b0aDaD5b97B2345cF2B8",
       "contract": "CErc20Immutable"
@@ -287,7 +287,7 @@
       "symbol": "cDAI",
       "decimals": 8,
       "address": "0xdb5Ed4605C11822811a39F94314fDb8F0fb59A2C",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "0xc2118d4d90b274016cB7a54c03EF52E6c537D957",
       "contract": "CErc20Delegator"
@@ -297,7 +297,7 @@
       "symbol": "cBAT",
       "decimals": 8,
       "address": "0x9E95c0b2412cE50C37a121622308e7a6177F819D",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "0x443Fd8D5766169416aE42B8E050fE9422f628419",
       "contract": "CErc20Immutable"
@@ -316,7 +316,7 @@
       "symbol": "cZRX",
       "decimals": 8,
       "address": "0x00e02a5200CE3D5b5743F5369Deb897946C88121",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "0xE4C6182EA459E63B8F1be7c428381994CcC2D49c",
       "contract": "CErc20Immutable"
@@ -326,7 +326,7 @@
       "symbol": "cWBTC",
       "decimals": 8,
       "address": "0x58145Bc5407D63dAF226e4870beeb744C588f149",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "20000000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "0xBde8bB00A7eF67007A96945B3a3621177B615C44",
       "contract": "CErc20Immutable"
@@ -336,7 +336,7 @@
       "symbol": "cUSDT",
       "decimals": 8,
       "address": "0x135669c2dcBd63F639582b313883F101a4497F76",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "0x516de3a7A567d81737e3a46ec4FF9cFD1fcb0136",
       "contract": "CErc20Delegator"
@@ -346,7 +346,7 @@
       "symbol": "cUSDC",
       "decimals": 8,
       "address": "0x8aF93cae804cC220D1A608d4FA54D1b6ca5EB361",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "0x0D9C8723B343A8368BebE0B5E89273fF8D712e3C",
       "contract": "CErc20Immutable"
@@ -356,7 +356,7 @@
       "symbol": "cETH",
       "decimals": 8,
       "address": "0xBe839b6D93E3eA47eFFcCA1F27841C917a8794f3",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "",
       "contract": "CEther"
@@ -366,7 +366,7 @@
       "symbol": "cSAI",
       "decimals": 8,
       "address": "0xc4d2A5872E16BC9E6557bE8B24683D96EB6ADca9",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "0x26fF7457496600C63b3E8902C9f871E60eDec4e4",
       "contract": "CErc20Immutable"
@@ -376,7 +376,7 @@
       "symbol": "cREP",
       "decimals": 8,
       "address": "0x8F2c8B147A3D316d2b98f32F3864746F034A55a2",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "0x6FD34013CDD2905d8d27b0aDaD5b97B2345cF2B8",
       "contract": "CErc20Immutable"
@@ -386,7 +386,7 @@
       "symbol": "cDAI",
       "decimals": 8,
       "address": "0xdb5Ed4605C11822811a39F94314fDb8F0fb59A2C",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "0xc2118d4d90b274016cB7a54c03EF52E6c537D957",
       "contract": "CErc20Delegator"
@@ -396,7 +396,7 @@
       "symbol": "cBAT",
       "decimals": 8,
       "address": "0x9E95c0b2412cE50C37a121622308e7a6177F819D",
-      "initial_exchange_rate_mantissa": "[object Object]",
+      "initial_exchange_rate_mantissa": "200000000000000000000000000",
       "admin": "0x9687EB285292cbA14a60a0c77dfD36dD95B93889",
       "underlying": "0x443Fd8D5766169416aE42B8E050fE9422f628419",
       "contract": "CErc20Immutable"


### PR DESCRIPTION
The networks files incorrectly had `[Object object]` for the initial exchange rate for cTokens. This patch fixes that issue. Additionally, we fix the ABI to use the new parameter names.