### PR TITLE
Fix Ropsten Gov

### DIFF
--- a/config/gov.js
+++ b/config/gov.js
@@ -114,9 +114,11 @@ define('Timelock', {
 });
 
 define('Governor', {
-  contract: 'GovernorAlpha',
+  contract: 'GovernorAlphaHarness',
   match: {
-    has_properties: ['harness']
+    properties: {
+      harness: true
+    }
   },
   properties: {
     harness: 'bool',

--- a/networks/ropsten.json
+++ b/networks/ropsten.json
@@ -32,7 +32,7 @@
     "cDAI": "0xdb5Ed4605C11822811a39F94314fDb8F0fb59A2C",
     "cBAT": "0x9E95c0b2412cE50C37a121622308e7a6177F819D",
     "reservoir": "0x4Aebe384D31e9309BEDf8552232C07591e0cA56F",
-    "GovernorAlpha": "0x5F36c2616248E4F725451cf6E9B0fE65ff2Bbe1F",
+    "GovernorAlpha": "0x5B9Ccf9B3473EA3e4FbC4d66B808459ff2c55906",
     "Maximillion": "0xE0a38ab2951B6525C33f20D5E637Ab24DFEF9bcB",
     "Comptroller": "0x54188bBeDD7b68228fa89CbDDa5e3e930459C6c6",
     "PriceOracleProxy": "0xb2b3d5B4E35881D518fa2062325F118A6Ebb6C4A"
@@ -69,7 +69,7 @@
     "cDAI": 8026361,
     "cBAT": 8026365,
     "reservoir": 8026391,
-    "GovernorAlpha": 8026395,
+    "GovernorAlpha": 8034061,
     "Maximillion": 8026452
   },
   "PriceOracle": {

--- a/state/ropsten-state.json
+++ b/state/ropsten-state.json
@@ -1076,12 +1076,12 @@
       },
       "harness": true
     },
-    "address": "0x5F36c2616248E4F725451cf6E9B0fE65ff2Bbe1F",
+    "address": "0x5B9Ccf9B3473EA3e4FbC4d66B808459ff2c55906",
     "definition": "Governor",
     "deployment": {
-      "block": 8026395,
+      "block": 8034061,
       "constructorData": "0000000000000000000000000a278af3cf0f5ba7a22133f0c165f6de2dcdf6890000000000000000000000001fe16de955718cfab7a44605458ab023838c27930000000000000000000000009687eb285292cba14a60a0c77dfd36dd95b93889",
-      "contract": "GovernorAlpha"
+      "contract": "GovernorAlphaHarness"
     },
     "verified": true
   },


### PR DESCRIPTION
We previously were using the official GovernorAlpha, not the Harness. This means that proposals take 3 days instead of one hour. This patch fixes that issue by replacing Ropsten's gov with a one-hour gov.