### PR TITLE
Add Ropsten Block

### DIFF
--- a/config/gov.js
+++ b/config/gov.js
@@ -83,7 +83,11 @@ define('Comp', {
   },
   contract: 'Comp',
   properties: {
-    address: 'address'
+    address: 'address',
+    block: {
+      type: 'number',
+      setter: async ({trx}, contract, block) => {}
+    }
   },
   build: async ({existing}, contract, { address }) => {
     return existing(contract, address);

--- a/config/networks.js
+++ b/config/networks.js
@@ -133,7 +133,11 @@ hook('state.save', async (state, {ethereum}) => {
     contractsJson.Comptroller = contractsJson.Unitroller; // Comptroller is special
     contractsJson.PriceOracleProxy = contractsJson.PriceOracle; // PriceOracle is *also* special
 
-    let blocksJson = mapContracts(state, refMap, null, ({deployment}) => deployment ? deployment.block : null);
+    let blocksJson = mapContracts(state, refMap, null, ({deployment, properties}) =>
+      deployment ? deployment.block : (
+        properties.block ? toNumber(properties.block) : null
+      )
+    );
 
     let priceOracleJson = mapContracts(
       state,

--- a/eureka/ropsten.eureka
+++ b/eureka/ropsten.eureka
@@ -23,4 +23,5 @@ Comp#comp [b73e68c] ! {
   decimals: 18
 
   address: "0x1fe16de955718cfab7a44605458ab023838c2793"
+  block: 7404113
 }

--- a/networks/ropsten.json
+++ b/networks/ropsten.json
@@ -56,6 +56,7 @@
     "BAT": 8026132,
     "Fauceteer": 8026135,
     "PriceOracle": 8026138,
+    "Comp": 7404113,
     "Timelock": 8026159,
     "Unitroller": 8026311,
     "cZRX": 8026328,

--- a/state/ropsten-state.json
+++ b/state/ropsten-state.json
@@ -499,7 +499,12 @@
         "exp": 0
       },
       "symbol": "COMP",
-      "name": "Comp"
+      "name": "Comp",
+      "block": {
+        "type": "number",
+        "base": 7404113,
+        "exp": 0
+      }
     },
     "address": "0x1fe16de955718cfab7a44605458ab023838c2793",
     "definition": "Comp",


### PR DESCRIPTION
This patch makes sure that we add the deployment block for Ropsten, even if it wasn't deployed from Eureka directly.