### PR TITLE
added support for custom networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ etherscan=$ETHERSCAN_API_KEY provider=https://ropsten-eth.compound.finance pk=$e
 
 For `ropsten.eureka`, we override Dai's underlying with a token from the test-net itself.
 
+## Private Network Deployment
+
+The network flag can be set to `custom` for users that are trying to deploy to a private test network. When using a custom network, also use the `-jsonrpc` command or `-j` and provide the JSON RPC endpoint of the private network. Be sure to create a `custom` file in the `.ethereum` folder of the user's home folder. Eureka will look for the user's private keys there, similarly to the Saddle commands in the [Compound Protocol repository](https://github.com/compound-finance/compound-protocol).
+
 ## Debugging
 
 There's lots of bugs in Eureka still. The focus, as yet, is to make sure the ideas are sound before pushing the code to a higher-quality state. Be prepared to need patches.

--- a/config/compound.js
+++ b/config/compound.js
@@ -10,7 +10,6 @@ backend({
 });
 
 // Set a provider to use to talk to an Ethereum node
-// TODO: Handle other networks here
 let defaultProvider = () => {
   if (network === 'development') {
     return 'http://localhost:8545';

--- a/config/compound.js
+++ b/config/compound.js
@@ -11,9 +11,15 @@ backend({
 
 // Set a provider to use to talk to an Ethereum node
 // TODO: Handle other networks here
-let defaultProvider = () =>
-  network === 'development' ? 'http://localhost:8545'
-    : `https://${network}-eth.compound.finance`;
+let defaultProvider = () => {
+  if (network === 'development') {
+    return 'http://localhost:8545';
+  } else if (network === 'custom' && jsonrpc.length > 0) {
+    return jsonrpc;
+  } else {
+    return `https://${network}-eth.compound.finance`;
+  }
+}
 
 let defaultPk = () =>
   network === 'development' ? { unlocked: 0 }

--- a/config/compound.js
+++ b/config/compound.js
@@ -33,7 +33,7 @@ provider(env('provider', defaultProvider), {
     gas: 6600000,
     gasPrice
   },
-  verificationOpts: network !== 'development' && env('etherscan') ? {
+  verificationOpts: network !== 'development' && network !== 'custom' && env('etherscan') ? {
     verify: true,
     etherscanApiKey: env('etherscan'),
     raiseOnError: false


### PR DESCRIPTION
Basically what I did was allow users to provide their network's JSON RPC URL to the Eureka commands without them breaking. It was limited strictly to the network names + "development" previously. Now someone can do `-n custom` and additionally `-j "https://whatever-eth.com"` in the command. Then Eureka will look in their `/User/name/.ethereum/custom` file for their keys when attempting to deploy.

related to: https://github.com/compound-finance/eureka/pull/2